### PR TITLE
Fix/issue 188 svd least squares for rectangular matrix

### DIFF
--- a/faer/src/linalg/solvers.rs
+++ b/faer/src/linalg/solvers.rs
@@ -2708,4 +2708,37 @@ mod tests {
 		assert!(&A * evd.U() ~ evd.U() * evd.S());
 		assert!(evd.S().column_vector() ~ ColRef::from_slice(&e));
 	}
+
+	#[test]
+	fn test_svd_solver_for_rectangular_matrix() {
+		#[rustfmt::skip]
+    	let A = crate::mat![
+    	    [4.,   5.,   7.],
+    	    [8.,   8.,   2.],
+    	    [4.,   0.,   9.],
+    	    [2.,   6.,   2.],
+    	    [0.,   6.,   0.],
+    	];
+		#[rustfmt::skip]
+    	let B = crate::mat![
+        	[105.,    49.],
+        	[ 98.,    54.],
+        	[113.,    35.],
+        	[ 46.,    34.],
+        	[ 12.,    24.],
+     	];
+
+		#[rustfmt::skip]
+	    let X_true= crate::mat![
+	      [8.,   2.],
+	      [2.,   4.],
+	      [9.,   3.],
+	    ];
+
+		let approx_eq = CwiseMat(ApproxEq::eps() * 128.0 * (A.nrows() as f64));
+		let svd = A.svd().unwrap();
+		let mut X = B.cloned();
+		svd.solve_lstsq_in_place_with_conj(crate::Conj::No, X.as_mat_mut());
+		assert!(X.get(..X_true.nrows(),..) ~ X_true);
+	}
 }

--- a/faer/src/linalg/solvers.rs
+++ b/faer/src/linalg/solvers.rs
@@ -2376,7 +2376,6 @@ impl<T: ComplexField> SolveLstsqCore<T> for Svd<T> {
 
 		let k = rhs.ncols();
 
-		let mut rhs = rhs;
 		let mut tmp = Mat::zeros(size, k);
 
 		linalg::matmul::matmul_with_conj(
@@ -2397,7 +2396,7 @@ impl<T: ComplexField> SolveLstsqCore<T> for Svd<T> {
 			}
 		}
 
-		linalg::matmul::matmul_with_conj(rhs.as_mut(), Accum::Replace, V, conj, tmp.as_ref(), Conj::No, one(), par);
+		linalg::matmul::matmul_with_conj(rhs.get_mut(..size, ..), Accum::Replace, V, conj, tmp.as_ref(), Conj::No, one(), par);
 	}
 }
 


### PR DESCRIPTION
This is a PR fixing https://github.com/sarah-quinones/faer-rs/issues/188, where the error was caused by the output matrix view not being cropped to the correct dimensions for the rectangular case.