### PR TITLE
add wasm test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,9 +64,37 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: nostd
-        run:
-          cd ./faer-no-std-test &&
+        run: |
+          cd ./faer-no-std-test
           cargo run --profile nostd
+
+  wasm:
+    name: wasm-${{ matrix.toolchain }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@master
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: wasm
+        run: |
+          cd ./faer-wasm-test
+          cargo test
 
   testing:
     name: testing-${{ matrix.toolchain }}-${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 ]
 exclude = [
   "faer-no-std-test",
+  "faer-wasm-test",
 ]
 
 resolver = "2"

--- a/faer-wasm-test/Cargo.toml
+++ b/faer-wasm-test/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "faer-wasm-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+# Ignore the parent workspace.
+[workspace]
+
+[dependencies]
+faer = { path = "../faer", default-features = false }
+libc = { version = "0.2.155", default-features = false }
+dlmalloc = { version = "0.2.8", features = ["global"] }
+
+[dev-dependencies]
+wasmtime = { version = "31.0.0", default-features = false, features = ["std", "cranelift", "runtime"] }
+
+[profile.dev]
+lto = true
+strip = true
+opt-level = 'z'
+codegen-units = 1
+panic = "abort"

--- a/faer-wasm-test/src/lib.rs
+++ b/faer-wasm-test/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+use dlmalloc::GlobalDlmalloc;
+
+#[global_allocator]
+static ALLOCATOR: GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+#[cfg(target_arch = "wasm32")]
+#[panic_handler]
+fn panic(_panic_info: &core::panic::PanicInfo) -> ! {
+	unreachable!()
+}
+
+#[no_mangle]
+pub extern "C" fn mul() -> f64 {
+	let m = faer::mat![[2.0, 1.0]];
+	let res = m.transpose() * &m;
+	*res.get(0, 0)
+}

--- a/faer-wasm-test/tests/load.rs
+++ b/faer-wasm-test/tests/load.rs
@@ -1,0 +1,47 @@
+use wasmtime::*;
+
+struct MyState {
+    name: String,
+    count: usize,
+}
+
+#[test]
+fn main() -> Result<()> {
+    let output = std::process::Command::new("cargo")
+        .args(["build", "--target", "wasm32-unknown-unknown"])
+        .output()
+        .expect("Failed to execute cargo command");
+
+    if !output.status.success() {
+        eprintln!("Cargo build failed: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("Failed to build WASM module");
+    }
+
+    let wasm_path = "target/wasm32-unknown-unknown/debug/faer_wasm_test.wasm";
+
+    println!("Compiling module...");
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, wasm_path)?;
+
+    println!("Initializing...");
+    let mut store = Store::new(
+        &engine,
+        MyState {
+            name: "faer test".to_string(),
+            count: 0,
+        },
+    );
+
+    println!("Instantiating module...");
+    let imports = [];
+    let instance = Instance::new(&mut store, &module, &imports)?;
+
+    println!("Extracting export...");
+    let run = instance.get_typed_func::<(), f64>(&mut store, "mul")?;
+
+    println!("Calling export...");
+    let result = run.call(&mut store, ())?;
+    assert_eq!(result, 4.0);
+
+    Ok(())
+}


### PR DESCRIPTION
I'm trying to use faer in a `no_std` `wasm32-unknown-unknown` environment (which seems to work again thanks to https://github.com/sarah-quinones/faer-rs/commit/b0bc791f39a446c87ad826cc424b905b6269baff). This is an useful combination when developing for wasm binaries that are distributed via the internet or in plugin systems. Having `no_std` saves a bit in the binary size (or compilation time) and `wasm32-unknown-unknown` is generally accepted because many plugin systems prefer to not allow WASI for security reasons (WASI is the system interface, so `wasm32-unknown-unknown` does not have printing enabled by default unlike the WASI `wasm32-wasip1` target).

This PR suggests to add a test for this case. I believe that if this barebone wasm lib works then more feature-full situations should also work. 

The compilation time is quite long with this PR though. Here I'm using wasmtime to verify that the wasm binary is correct and can be used as a lib. However, this requires using the Rust interface and hence compiling wasmtime. If this takes too long, then I can probably also run via some other wasm runtime and check the output via Javascript.

### EDIT 2025-03-26 14:15 UTC

What could also work is doing a very basic smoke test. So only add this simple job:
```yml
    steps:
      - name: Checkout source
        uses: actions/checkout@master

      - name: Install toolchain
        uses: dtolnay/rust-toolchain@master
        with:
          toolchain: ${{ matrix.toolchain }}
          targets: wasm32-unknown-unknown

      - uses: Swatinem/rust-cache@v2

      - name: Smoke test wasm build
        run: cargo build --target wasm32-unknown-unknown
```
and remove the `faer-wasm-test` from this PR. Or remove only `faer-wasm-test/tests/` and just do
```yml
run: |
    cd faer-wasm-test
    cargo build --target wasm32-unknown-unknown
```
This would be pretty reasonable IMO because if the compilation succeeds then probably it works.