### PR TITLE
chore: report the code lint errors

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,19 +20,12 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: clippy, rustfmt, rust-src, miri
+          components: clippy, rustfmt
 
       - name: Formatting check
-        run:
-          cargo fmt --all -- --check &&
-          cd ./faer-entity &&
-          cargo fmt --all -- --check
-        # want to get all quality issues
-        continue-on-error: true
+        run: cargo +nightly fmt --all -- --check
 
       - name: Linting check
-        run:
-          cargo clippy --all-targets &&
-          cd ./faer-entity &&
-          cargo clippy --all-targets
-        continue-on-error: true
+        env:
+          RUSTFLAGS: -Awarnings # ignore warnings for clippy
+        run: cargo clippy --all-targets

--- a/faer-traits/src/lib.rs
+++ b/faer-traits/src/lib.rs
@@ -1084,6 +1084,7 @@ pub trait ComplexField:
 	fn mul_pow2_impl(lhs: &Self, rhs: &Self::Real) -> Self;
 
 	fn is_finite_impl(value: &Self) -> bool;
+	#[allow(clippy::eq_op)]
 	fn is_nan_impl(value: &Self) -> bool {
 		value != value
 	}

--- a/faer/src/linalg/evd/schur/real_schur.rs
+++ b/faer/src/linalg/evd/schur/real_schur.rs
@@ -697,6 +697,7 @@ fn aggressive_early_deflation<T: RealField>(
 	}
 	v.fill(zero());
 	v.rb_mut().diagonal_mut().fill(one::<T>());
+	#[allow(clippy::overly_complex_bool_expr)]
 	let infqr = if true || jw < params.blocking_threshold {
 		lahqr(true, tw.rb_mut(), Some(v.rb_mut()), s_re_window.rb_mut(), s_im_window.rb_mut(), 0, jw)
 	} else {

--- a/faer/src/utils/approx.rs
+++ b/faer/src/utils/approx.rs
@@ -114,6 +114,7 @@ impl<R: RealField, T: ComplexField<Real = R>> equator::Cmp<T, T> for ApproxEq<R>
 		let diff = abs(*lhs - *rhs);
 		let max = max(abs(*lhs), abs(*rhs));
 
+		#[allow(clippy::overly_complex_bool_expr)]
 		if (max == zero() && diff <= *abs_tol) || (diff <= *abs_tol || diff <= *rel_tol * max) {
 			Ok(())
 		} else {


### PR DESCRIPTION
Previously, the lint errors were suppressed by `continue-on-error: true`.

I ignored all the clippy warnings because there are 1000+ warnings there.

`is_nan_impl` should have the `#[allow(clippy::eq_op)]`, the same to the std impl.

For the code in real_schur, I guess it's intended.

For the code in approx, I'm not sure about the `(max == zero() && diff <= *abs_tol)` condition.